### PR TITLE
Made dynamic placeholders inside of a listview possible.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,32 @@ Install via nuget
 
 Use the Control DynamicKeyPlaceholder instead of a Sitecore Placeholder control. 
 
+To get DynamicKeyPlaceholders to work inside of ListViews, you also have to manually change /sitecore/shell/Applications/Page Modes/ChromeTypes/PlaceholderChromeType.js on line 34 from:
+```
+addControlResponse: function(id, openProperties, ds) {                       
+    var options = Sitecore.PageModes.ChromeTypes.Placeholder.getDefaultAjaxOptions("insert");
+    options.context = this;    
+    options.data.rendering = id;
+    options.data.placeholderKey = this.placeholderKey();
+    [...]           
+```
+
+to:
+```
+addControlResponse: function (id, openProperties, ds) {
+    var phkey = this.placeholderKey();
+    var options = Sitecore.PageModes.ChromeTypes.Placeholder.getDefaultAjaxOptions("insert");
+    options.context = this;
+    options.data.rendering = id;
+    if (phkey.match(/{{.*}}/ig)) {
+        options.data.placeholderKey = phkey.substring(phkey.lastIndexOf("/"));
+    } else {
+        options.data.placeholderKey = phkey;
+    }
+    [...]
+```
+
+
 ## Example of use
 ```
 <%@ Control Language="C#" AutoEventWireup="true" CodeBehind="SpotsContainer.ascx.cs" Inherits="Web.UI.SpotsContainer" %>

--- a/src/Controls/DynamicKeyPlaceholder.cs
+++ b/src/Controls/DynamicKeyPlaceholder.cs
@@ -23,6 +23,12 @@
             set
             {
                 _key = value.ToLower();
+                if (_placeholder != null)
+                {
+                    // need to reset child controls if key is changed after placeholder was initialized.
+                    this.Controls.Clear();
+                    CreateChildControls();
+                }
             }
         }
 
@@ -30,26 +36,54 @@
         {
             get
             {
-                if (_dynamicKey != null)
-                {
-                    return _dynamicKey;
-                }
                 _dynamicKey = _key;
-                
+
                 //find the last placeholder processed, will help us find our parent
                 Stack<Placeholder> stack = Switcher<Placeholder, PlaceholderSwitcher>.GetStack(false);
-                Placeholder current = stack.Peek();
-                
-                //find the rendering reference we are contained in
-                var renderings = Sitecore.Context.Page.Renderings.Where(rendering => (rendering.Placeholder == current.ContextKey || rendering.Placeholder == current.Key) && rendering.AddedToPage);
-                if (renderings.Any())
+                if (stack.Count > 0)
                 {
-                    //last one added to page defines our parent
-                    var thisRendering = renderings.Last();
-                    _dynamicKey = _key + thisRendering.UniqueId;
+                    Placeholder current = stack.Peek();
+
+                    //find the rendering reference we are contained in
+                    var renderings =
+                        Sitecore.Context.Page.Renderings.Where(
+                            rendering =>
+                                (rendering.Placeholder == current.ContextKey || rendering.Placeholder == current.Key)
+                                && rendering.AddedToPage);
+                    if (renderings.Any())
+                    {
+                        //last one added to page defines our parent
+                        var thisRendering = renderings.Last();
+                        _dynamicKey = _key + thisRendering.UniqueId;
+                    }
+                }
+                else
+                {
+                    // Stack is empty -> This can happen inside of a listview... let's check.
+                    var editFrame = this.Parent;
+                    var closestListView = GetAncestorOfType(editFrame, "System.Web.UI.WebControls.ListViewDataItem");
+                    if (closestListView != null)
+                    {
+                        // Ok this is inside of a listview, here things work a bit different.
+                        // Since we still need a unique placeholderkey, we will just use unique id of our editFrame
+                        _dynamicKey = _key + "{{" + editFrame.UniqueID.Replace("$", "") + "}}";
+                    }
                 }
                 return _dynamicKey;
             }
+        }
+
+        public static Control GetAncestorOfType(Control ctrl, string typeName)
+        {
+            if (ctrl.Parent == null)
+            {
+                return null;
+            }
+            if (ctrl.GetType().ToString().Equals(typeName))
+            {
+                return ctrl;
+            }
+            return GetAncestorOfType(ctrl.Parent, typeName);
         }
 
         protected override void CreateChildControls()

--- a/src/Pipelines/GetPlaceholderRenderings/GetDynamicKeyAllowedRenderings.cs
+++ b/src/Pipelines/GetPlaceholderRenderings/GetDynamicKeyAllowedRenderings.cs
@@ -16,8 +16,8 @@
     /// </summary>
     public class GetDynamicKeyAllowedRenderings : GetAllowedRenderings
     {
-        //text that ends in a GUID
-        public const string DYNAMIC_KEY_REGEX = @"(.+){[\d\w]{8}\-([\d\w]{4}\-){3}[\d\w]{12}}";
+        //text that ends in a GUID or {{uniqueId}}
+        public const string DYNAMIC_KEY_REGEX = @"(.+)(?:{[\d\w]{8}\-([\d\w]{4}\-){3}[\d\w]{12}}|{{.+}})";
 
         public new void Process(GetPlaceholderRenderingsArgs args)
         {


### PR DESCRIPTION
Using the placeholder inside a listview resulted in an error, saying the stack is empty.
So I modified the code to include a uniqueid, to still work in those cases.